### PR TITLE
Set box sizing to border-box and font size to 62.5%

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -11,3 +11,11 @@ code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, "Courier New",
     monospace;
 }
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  font-size: 62.5%;
+}


### PR DESCRIPTION
# Description


Set box sizing to border-box and font size to 62.5% so we can use rem instead of px

Fixes # (issue)



## Type of change


Please add a relevant label.


## Change status


- [ ] Complete, tested, ready to review and merge

- [x] Complete, but not tested (may need new tests)

- [ ] Incomplete/work-in-progress, PR is for discussion/feedback



# How Has This Been Tested?



Please describe steps taken to ensure this feature is functional and does not break other features:
Tested in the browser


# Checklist:



- [x] My code follows the style guidelines of this project

- [x] I have performed a self-review of my own code

- [x] I have commented my code, particularly in hard-to-understand areas

- [x] I have made corresponding changes to the documentation, if relevant

- [x] I have run the app using my feature and ensured that no functionality is broken

- [x] My changes generate no new warnings

- [x] There are no merge conflicts
